### PR TITLE
Reduce image size by ~200MB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN set -ex \
     scipy \
  ' \
  && pip3 install $packages \
+ && rm -rf /root/.cache/pip \
  && apt-get purge -y --auto-remove $buildDeps \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
@@ -56,6 +57,7 @@ RUN set -ex \
  && rm -rf /usr/src/zeppelin \
  && rm -rf /root/.m2 \
  && rm -rf /root/.npm \
+ && rm -rf /root/.cache/bower \
  && rm -rf /tmp/*
 
 RUN ln -s /usr/bin/pip3 /usr/bin/pip \


### PR DESCRIPTION
This removes unnecessary caches and so reduces the image size by 200MB (~10%).
(Numbers taken with Spark 2.2 and Zeppelin 0.7.3)

<img width="664" alt="reduced-image-size" src="https://user-images.githubusercontent.com/352767/31686191-c4087ad2-b385-11e7-9e0a-9765ba4bf64c.png">
